### PR TITLE
Update project documentation and configurations

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,13 +1,19 @@
 {
-  "servers": {
-    "github-mcp": {
-      "url": "https://api.githubcopilot.com/mcp/",
-      "type": "http"
-    },
-    "synth-local": {
-      "type": "http",
-      "url": "http://127.0.0.1:8010/mcp",
-      "toolAllowList": ["synth_generate", "synth_inspect_model", "preview_table_head"]
-    }
-  },
+	"servers": {
+		"github-mcp": {
+			"url": "https://api.githubcopilot.com/mcp/",
+			"type": "http"
+		},
+		"synth-local": {
+			"type": "http",
+			"url": "http://127.0.0.1:8010/mcp",
+			"toolAllowList": [
+				"synth_generate",
+				"synth_inspect_model",
+				"preview_table_head",
+				"synth_stats"
+			]
+		}
+	},
+	"inputs": []
 }

--- a/airline-discount-ml/setup.py
+++ b/airline-discount-ml/setup.py
@@ -1,12 +1,16 @@
 from setuptools import setup, find_packages
 
+# Read README with proper encoding and resource management
+with open('README.md', encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(
     name='airline_discount_ml',
     version='0.1.0',
     author='Airline ML Team',
     author_email='team@airline-ml.com',
     description='A training project for learning GitHub Copilot with ML - generates customized airline discounts',
-    long_description=open('README.md', encoding='utf-8').read(),
+    long_description=long_description,
     long_description_content_type='text/markdown',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},

--- a/airline-discount-ml/setup.py
+++ b/airline-discount-ml/setup.py
@@ -6,7 +6,7 @@ setup(
     author='Airline ML Team',
     author_email='team@airline-ml.com',
     description='A training project for learning GitHub Copilot with ML - generates customized airline discounts',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},


### PR DESCRIPTION
## Summary
This PR includes two focused improvements to configuration files for better cross-platform compatibility and MCP server integration.

## Changes Made

### 1. Fixed UTF-8 Encoding in setup.py ✅
**File:** `airline-discount-ml/setup.py`
- **Problem:** README.md reading could fail on Windows with non-ASCII characters
- **Solution:** Added `encoding='utf-8'` parameter and used context manager for proper resource handling
- **Impact:** Prevents `UnicodeDecodeError` during package installation on Windows systems
- **Best Practice:** Context manager ensures file handle is properly closed

### 2. Added synth_stats Tool to MCP Configuration ✅
**File:** `.vscode/mcp.json`
- **Problem:** Missing `synth_stats` tool from MCP server allowlist
- **Solution:** Added `synth_stats` to `toolAllowList` for synth-local server
- **Purpose:** Enables data statistics generation functionality via MCP server
- **Server Implementation:** Corresponds to `/synth_stats` endpoint in `src/mcp_synth/server.py`

### Note on Formatting
The mcp.json file was also reformatted (spaces → tabs) for consistency with VS Code default JSON formatting. This is intentional standardization.

## Testing

### Manual Testing Completed:
- ✅ Verified `synth_stats` endpoint exists in `src/mcp_synth/server.py` (lines 167-227)
- ✅ JSON configuration is valid and parseable
- ✅ setup.py successfully reads README.md with UTF-8 encoding

### Why No Unit Tests Changed:
- Configuration file changes don't require new tests
- Existing MCP server tests already cover the `synth_stats` functionality
- setup.py change is a safe improvement (adding explicit encoding)

## Backward Compatibility
✅ Both changes are backward compatible:
- UTF-8 encoding is default on most systems (now explicit)
- Adding tool to allowlist enables feature without breaking existing tools

## Related Work
- MCP server implementation: `airline-discount-ml/src/mcp_synth/server.py`
- Server tests: `airline-discount-ml/tests/mcp_synth/test_server.py`